### PR TITLE
fix: cleanupSpacing(): cleans tab/space/zwnj/zwj/nbsp between two new…

### DIFF
--- a/lib/virastar.js
+++ b/lib/virastar.js
@@ -983,10 +983,10 @@
       // .replace(/(?<![_]{2})([ ]{2,})(?![_]{2}|\n)/g, ' ') // WORKS: using lookbehind
       .replace(/([^_])([ ]{2,})(?![_]{2}|\n)/g, '$1 ')
 
-      // cleans whitespace/zwnj between new-lines
+      // cleans tab/space/zwnj/zwj/nbsp between two new-lines(\n)
       // @REF: https://stackoverflow.com/a/10965543/
-      .replace(/\n[\s\u200c]*\n/g, '\n\n')
-    ;
+      .replace(/^\n([\t\u0020\u200c\u200d\u00a0]*)\n$/gm, '\n\n')
+    
   }
 
   function cleanupLineBreaks (text) {


### PR DESCRIPTION
سلام
تو یک پروژه نیاز داشتم هرچی (\n) تو متن هست، سر جای خودش باقی بمونه! که دیدم حذف میشه و به این باگ بر خوردم و اصلاحش کردم.
خلاصه: در تابع cleanupSpacing() چک می‌کنه بین دو خط جدید(\n) کارکترهای tab/space/zwnj/zwj/nbsp وجود نداشته باشد. اگر بود آنرا پاکسازی می‌کنید.
حالا هرجایی نیاز بود که خط‌های خالی اضافه حذف بشه cleanupLineBreaks این کار رو انجام میده.

این [لینک ](https://r12a.github.io/uniview/?charlist=%D9%85%DB%8C%0A%0A%E2%80%8D%0A%0A%0A%20%0A%0A%E2%80%8C%0A%0A%0A%DA%A9%D9%86%D8%AF) یک نمونه متن برای تست و این هم تصویر کاراکتر مپ‌های این متن:

![image](https://user-images.githubusercontent.com/174688/151984985-1b6994d5-4c4e-4cc7-9683-f71a41dfd548.png)

